### PR TITLE
Add address_line2 property to validation rules

### DIFF
--- a/app/Http/Controllers/OfficeController.php
+++ b/app/Http/Controllers/OfficeController.php
@@ -56,6 +56,7 @@ class OfficeController extends Controller
                 'lat' => ['required', 'numeric'],
                 'lng' => ['required', 'numeric'],
                 'address_line1' => ['required', 'string'],
+                'address_line2' => ['string'],
                 'hidden' => ['bool'],
                 'price_per_day' => ['required', 'integer', 'min:100'],
                 'monthly_discount' => ['integer', 'min:0', 'max:90'],


### PR DESCRIPTION
Even though it's optional, it wouldn't be saved if a second addressline was provided.

Thanks for the great streams :) Always learning new tricks even as an experienced Laravel dev