### PR TITLE
Remove unnecessary square root

### DIFF
--- a/app/Models/Office.php
+++ b/app/Models/Office.php
@@ -53,7 +53,7 @@ class Office extends Model
         return $builder
             ->select()
             ->orderByRaw(
-                'SQRT(POW(69.1 * (lat - ?), 2) + POW(69.1 * (? - lng) * COS(lat / 57.3), 2))',
+                'POW(69.1 * (lat - ?), 2) + POW(69.1 * (? - lng) * COS(lat / 57.3), 2)',
                 [$lat, $lng]
             );
     }


### PR DESCRIPTION
The square root is not necessary for the ordering since `a < b <=> √a < √b` for all positive numbers (distances) `a` and `b`. This improves performance as the database grows.

This is also mentioned in a comment to the SO-answer referenced:
https://stackoverflow.com/questions/2234204/find-nearest-latitude-longitude-with-an-sql-query