### PR TITLE
[#30] Fix image path failing test and add Laravel Sail support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,10 @@
-APP_NAME=Laravel
+APP_NAME=Ergodnc
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_URL=http://ergodnc.test:8000
+APP_SERVICE=ergodnc
+APP_PORT=8000
 
 LOG_CHANNEL=stack
 LOG_LEVEL=debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+# For more information: https://laravel.com/docs/sail
+version: '3'
+services:
+    ergodnc:
+        build:
+            context: ./vendor/laravel/sail/runtimes/8.0
+            dockerfile: Dockerfile
+            args:
+                WWWGROUP: '${WWWGROUP}'
+        image: sail-8.0/app
+        extra_hosts:
+            - 'host.docker.internal:host-gateway'
+        ports:
+            - '${APP_PORT:-80}:80'
+        environment:
+            WWWUSER: '${WWWUSER}'
+            LARAVEL_SAIL: 1
+            XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
+            XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
+        depends_on:
+            - mysql
+    mysql:
+        image: 'mariadb:latest'
+        ports:
+            - '${FORWARD_DB_PORT:-3306}:3306'
+        environment:
+            MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_DATABASE: '${DB_DATABASE}'
+            MYSQL_USER: '${DB_USERNAME}'
+            MYSQL_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+        volumes:
+            - 'sailmysql:/var/lib/mysql'
+        networks:
+            - sail
+        healthcheck:
+            test: ["CMD", "mysqladmin", "ping", "-p${DB_PASSWORD}"]
+            retries: 3
+            timeout: 5s
+networks:
+    sail:
+        driver: bridge
+volumes:
+    sailmysql:
+        driver: local

--- a/tests/Feature/OfficeImageControllerTest.php
+++ b/tests/Feature/OfficeImageControllerTest.php
@@ -34,7 +34,7 @@ class OfficeImageControllerTest extends TestCase
         $response->assertCreated();
 
         Storage::assertExists(
-            $response->json('data.path')
+            $office->refresh()->path
         );
     }
 


### PR DESCRIPTION
This pull request fixes the image path in the failing test where it uses the relative path instead of the full URL. [#30 ]

It also brings support for Laravel Sail for those who use it instead of a custom local development environments.