### PR TITLE
If VerifyEmail is used redirect to the frontend

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -15,7 +15,7 @@ class Authenticate extends Middleware
     protected function redirectTo($request)
     {
         if (! $request->expectsJson()) {
-            return route('login');
+            return url(env('FRONTEND_URL') . '/login');
         }
     }
 }


### PR DESCRIPTION
If email verification is switched on a user will need to be redirected back to the front end login page not the API.

This PR adds the redirect back to the front end.